### PR TITLE
Enhance app menu with icon removal option and update README with GNOME 50 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a part of the WACK project (WACK Ain't Cupertino, Kid), a collection of 
   Adds a customizable logo button to the far left of the panel — pick from 34 pre-defined distro icons (Apple, Fedora, Arch, and more), use symbolic or colored variants, or supply your own SVG/PNG. Add an optional text label beside it. Clicking opens a macOS-style system menu with quick access to About My System, System Settings, App Grid, Software Center, System Monitor, Terminal, Extensions, Force Quit App, and optionally power controls (Sleep, Restart, Shut Down, Log Out, Lock Screen). Each launcher command is user-configurable, and individual menu items can be shown or hidden. Left- and middle-click actions are independently configurable: open the menu or toggle the Overview. <br><br>
 
 - **App Menu** <br>
-  Shows the focused application's name and icon next to the logo, macOS menu-bar style. Fades in and out smoothly on focus change and overview toggle. Icon can be displayed in symbolic or full color. <br><br>
+  Shows the focused application's name and (optionally) icon next to the logo, macOS menu-bar style. Fades in and out smoothly on focus change and overview toggle. Icon can be displayed in symbolic or full color. <br><br>
 
 - **Workspace Widget** <br>
   A separate widget placed next to the logo — choose between animated workspace dot indicators (à la GNOME 45 lock screen) or a classic Activities label. The label variant optionally appends the current workspace number (e.g. *Activities • 2*). Scroll over either widget to switch workspaces, with an optional workspace switcher HUD popup. <br><br>
@@ -40,7 +40,7 @@ Running `make install` again is sufficient to update — it syncs the directory 
 
 ## Compatibility
 
-Developed and tested on GNOME 46 and 49 (Fedora/Nobara). GNOME 47–48 are untested but should work fine. Open an issue if you run into something, or clone and contribute.
+Developed and tested on GNOME 46, 49 and 50 (Fedora/Nobara). GNOME 47–48 are untested but should work fine. Open an issue if you run into something, or clone and contribute.
 
 ## About the WACK Project
 

--- a/extension.js
+++ b/extension.js
@@ -71,12 +71,14 @@ export default class WackShellExtension extends Extension {
         this._sessionModeOwner = {};
         Main.sessionMode.connectObject('updated', () => this._syncSessionModeUI(), this._sessionModeOwner);
 
-        this._settings.connectObject(
-            'changed::show-logo-menu', () => this._syncLogoMenu(),
-            'changed::show-workspace-widget', () => this._syncWorkspaceWidget(),
-            'changed::show-app-menu', () => this._syncAppMenu(),
-            this
-        );
+this._settings.connectObject(
+    'changed::show-logo-menu', () => this._syncLogoMenu(),
+    'changed::show-workspace-widget', () => this._syncWorkspaceWidget(),
+    'changed::show-app-menu', () => this._syncAppMenu(),
+    'changed::show-app-menu-icon', () => this._appMenuButton?._updateAppMenuVisibility(),
+    'changed::show-app-menu-label', () => this._appMenuButton?._updateAppMenuVisibility(),
+    this
+);
 
         this._syncLogoMenu();
         this._syncWorkspaceWidget();

--- a/panelComponents.js
+++ b/panelComponents.js
@@ -548,7 +548,8 @@ export const WackAppMenuButton = GObject.registerClass({
         this.bind_property('reactive', this, 'can-focus', 0);
         this.reactive = false;
 
-        this._container = new St.BoxLayout({ style_class: 'panel-status-menu-box' });
+        this._container = new St.BoxLayout({ style_class: 'panel-status-menu-box' , y_align: Clutter.ActorAlign.CENTER,
+        });
         bin.set_child(this._container);
 
         this._desaturateEffect = new Clutter.DesaturateEffect();
@@ -560,8 +561,8 @@ export const WackAppMenuButton = GObject.registerClass({
         this._container.add_child(this._iconBox);
 
         this._label = new St.Label({
-            y_expand: true,
             y_align: Clutter.ActorAlign.CENTER,
+            
         });
         this._container.add_child(this._label);
 
@@ -585,10 +586,15 @@ export const WackAppMenuButton = GObject.registerClass({
         global.window_manager.connectObject('switch-workspace',
             this._sync.bind(this), this);
 
-        this._settings.connectObject('changed::colored-app-menu-icon',
-            this._updateIconEffect.bind(this), this);
+        this._settings.connectObject(
+    'changed::colored-app-menu-icon',       this._updateIconEffect.bind(this),
+    'changed::show-app-menu-icon', this._updateAppMenuVisibility.bind(this),
+    'changed::show-app-menu-label', this._updateAppMenuVisibility.bind(this),
+    this
+);
 
         this._updateIconEffect();
+        this._updateAppMenuVisibility();
         this._sync(true);
     }
 
@@ -760,6 +766,24 @@ export const WackAppMenuButton = GObject.registerClass({
             this._iconBox.style = 'margin-right: 4px; -st-icon-style: symbolic';
         }
     }
+    
+    _updateAppMenuVisibility() {
+    const showIcon = this._settings.get_boolean('show-app-menu-icon');
+    const showLabel = this._settings.get_boolean('show-app-menu-label');
+
+    if (showIcon) {
+        this._iconBox.show();
+    } else {
+        this._iconBox.hide();
+    }
+
+    if (showLabel) {
+        this._label.show();
+    } else {
+        this._label.hide();
+    }
+}
+
 
     destroy() {
         this._targetApp?.disconnectObject(this);
@@ -778,6 +802,8 @@ export const WackAppMenuButton = GObject.registerClass({
         super.destroy();
     }
 });
+
+
 
 export const WackWorkspaceButton = GObject.registerClass(
     class WackWorkspaceButton extends PanelMenu.Button {

--- a/prefs.js
+++ b/prefs.js
@@ -169,7 +169,7 @@ export default class WackShellPreferences extends ExtensionPreferences {
             icon_name: 'preferences-system-symbolic',
         });
 
-        // Group 2.1: Panel Objects
+       // Group 2.1: Panel Objects
         const visibilityGroup = new Adw.PreferencesGroup({
             title: 'Panel Objects',
         });
@@ -182,30 +182,55 @@ export default class WackShellPreferences extends ExtensionPreferences {
             'Display the logo menu button at the far left'
         ));
 
-        visibilityGroup.add(this._buildSwitchRow(
+        const showAppMenuRow = this._buildSwitchRow(
             settings,
             settingsSignalIds,
             'show-app-menu',
             'Show App Menu Button',
             'Display the focused application name next to the logo'
-        ));
+        );
+        visibilityGroup.add(showAppMenuRow);
 
+       
+        const showAppIconRow = this._buildSwitchRow(
+            settings,
+            settingsSignalIds,
+            'show-app-menu-icon',
+            'Show App Menu Icon',
+            'Display the application icon next to the application\'s name'
+        );
+        visibilityGroup.add(showAppIconRow);
+
+        
         const coloredAppIconRow = this._buildSwitchRow(
             settings,
             settingsSignalIds,
             'colored-app-menu-icon',
-            'Colored App Menu Icon',
-            'Display the application icon in color instead of monochrome'
+            'Coloured App Menu Icon',
+            'Display the application icon in colour instead of monochrome'
         );
         visibilityGroup.add(coloredAppIconRow);
 
-        const updateColoredAppIconSensitivity = () => {
-            coloredAppIconRow.sensitive = settings.get_boolean('show-app-menu');
-        };
-        const showAppMenuSig = settings.connect('changed::show-app-menu', updateColoredAppIconSensitivity);
-        settingsSignalIds.push(showAppMenuSig);
-        updateColoredAppIconSensitivity();
+        
 
+        // Grey out 'show-app-menu-icon' if 'show-app-menu' is false
+        const updateIconSensitivity = () => {
+            const hasAppMenu = settings.get_boolean('show-app-menu');
+            showAppIconRow.sensitive = hasAppMenu;
+            
+            const hasAppIcon = settings.get_boolean('show-app-menu-icon');
+            coloredAppIconRow.sensitive = hasAppMenu && hasAppIcon;
+        };
+
+      
+        const sigAppMenu = settings.connect('changed::show-app-menu', updateIconSensitivity);
+        const sigAppIcon = settings.connect('changed::show-app-menu-icon', updateIconSensitivity);
+        settingsSignalIds.push(sigAppMenu, sigAppIcon);
+
+        // Set initial states
+        updateIconSensitivity();
+
+        // 4. Show Workspace Widget Toggle
         visibilityGroup.add(this._buildSwitchRow(
             settings,
             settingsSignalIds,
@@ -613,7 +638,7 @@ export default class WackShellPreferences extends ExtensionPreferences {
             settingsSignalIds,
             'enable-panel-proximity',
             'Enable/Disable Proximity',
-            'Automatically switch panel opacity/color when windows are maximised or close to the panel.'
+            'Automatically switch panel opacity/colour when windows are maximised or close to the panel.'
         ));
 
         // Dark Mode Colors Expander
@@ -658,7 +683,7 @@ export default class WackShellPreferences extends ExtensionPreferences {
             settingsSignalIds,
             'symbolic-logo',
             'Use Symbolic Icon',
-            'Toggle symbolic (monochrome) vs colored style'
+            'Toggle symbolic (monochrome) vs coloured style'
         ));
 
         logoOptionsGroup.add(this._buildSwitchRow(

--- a/schemas/org.gnome.shell.extensions.wack-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.wack-shell.gschema.xml
@@ -110,8 +110,8 @@
 
     <key type="b" name="hide-softwarecentre">
       <default>false</default>
-      <summary>Hide Software Center Option</summary>
-      <description>Hide the Software Center option in the Logo Menu.</description>
+      <summary>Hide Software Manager Option</summary>
+      <description>Hide the Software Manager option in the Logo Menu.</description>
     </key>
 
     <!-- External Apps -->
@@ -122,7 +122,7 @@
 
     <key type="s" name="menu-button-software-center">
       <default>"gnome-software"</default>
-      <summary>Software Center Application Command</summary>
+      <summary>Software Manager Application Command</summary>
     </key>
 
     <key type="s" name="menu-button-system-monitor">
@@ -137,33 +137,47 @@
 
     <key type="b" name="enable-panel-proximity">
       <default>true</default>
-      <summary>Enable Panel Proximity Coloring</summary>
+      <summary>Enable Panel Proximity Colouring</summary>
     </key>
 
     <key type="s" name="dark-bg-color">
       <default>'rgb(0, 0, 0)'</default>
-      <summary>Custom dark mode background color</summary>
+      <summary>Custom dark mode background colour</summary>
     </key>
 
     <key type="s" name="dark-fg-color">
       <default>'rgb(240, 240, 240)'</default>
-      <summary>Custom dark mode foreground color</summary>
+      <summary>Custom dark mode foreground colour</summary>
     </key>
 
     <key type="s" name="light-bg-color">
       <default>'rgb(250, 250, 250)'</default>
-      <summary>Custom light mode background color</summary>
+      <summary>Custom light mode background colour</summary>
     </key>
 
     <key type="s" name="light-fg-color">
       <default>'rgb(0, 0, 0)'</default>
-      <summary>Custom light mode foreground color</summary>
+      <summary>Custom light mode foreground colour</summary>
     </key>
+    
+    
+    <key type="b" name="show-app-menu-label">
+      <default>true</default>
+      <summary>Show App Menu Label</summary>
+      <description>Show or hide the active application name label in the top panel.</description>
+    </key>
+    
+    <key type="b" name="show-app-menu-icon">
+      <default>true</default>
+      <summary>Show App Menu Icon</summary>
+      <description>Show or hide the active application icon in the top panel.</description>
+    </key>
+
 
     <key type="b" name="colored-app-menu-icon">
       <default>false</default>
-      <summary>Colored App Menu Icon</summary>
-      <description>Show the active application icon in color rather than monochrome.</description>
+      <summary>Coloured App Menu Icon</summary>
+      <description>Show the active application icon in colour rather than monochrome.</description>
     </key>
 
 


### PR DESCRIPTION
I also updated certain spellings in the UI to international spellings (I'm American). Everything aligns well (I use the Kiwi Menu which appears to be misaligned here but I will be fixing that outside the scope of this repo)

<img width="1366" height="34" alt="Screenshot From 2026-08-08 14-47-24" src="https://github.com/user-attachments/assets/2d24821a-667d-4de0-a2a3-8b05209d5198" />
