### PR TITLE
Fix: Sync app menu hover state on app focus

### DIFF
--- a/panelComponents.js
+++ b/panelComponents.js
@@ -747,6 +747,7 @@ export const WackAppMenuButton = GObject.registerClass({
                 this._targetApp.get_busy());
 
         this.reactive = visible && !isBusy;
+        this.sync_hover(); //after an app is focused, this ensures the appmenu is not being hovered over without the cursor over it
 
         this.menu.setApp(this._targetApp);
         this.emit('changed');


### PR DESCRIPTION
The app menu could remain visually hovered after resuming from suspend and unlocking, even when the pointer wasn't over it.
To fix it, it's a one-liner: I called sync_hover() after updating the button's reactive state so GNOME Shell reconciles the hover pseudo-class with the pointer's actual position.